### PR TITLE
Only read first 512 bytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,34 @@
 var fs = require('fs');
 
 module.exports = function(bytes, size) {
+    var max_bytes = 512;
+
     // Read the file with no encoding for raw buffer access.
     if (size === undefined) {
         var file = bytes;
         if (!fs.existsSync(file))
            return false;
-        bytes = fs.readFileSync(file);
-        size = fs.statSync(file).size;
-    } 
+        var descriptor = fs.openSync(file, 'r');
+        try {
+          bytes = new Buffer(max_bytes);
+          size = fs.readSync(descriptor, bytes, 0, bytes.length, 0);
+        } finally {
+          fs.closeSync(descriptor);
+        }
+    }
 
-    if (size == 0) 
+    if (size == 0)
         return false;
 
     var suspicious_bytes = 0;
-    var total_bytes = size > 512 ? 512 : size;
-    
+    var total_bytes = Math.min(size, max_bytes);
+
     if (size >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) {
         // UTF-8 BOM. This isn't binary.
         return false;
     }
 
-    for (var i = 0; i < total_bytes; i++) {  
+    for (var i = 0; i < total_bytes; i++) {
         if (bytes[i] == 0) { // NULL byte--it's binary!
             return true;
         }
@@ -32,7 +39,7 @@ module.exports = function(bytes, size) {
                 if (bytes[i] < 192) {
                     continue;
                 }
-            } 
+            }
             else if (bytes[i] > 223 && bytes[i] < 239 && i + 2 < total_bytes) {
                 i++;
                 if (bytes[i] < 192 && bytes[i + 1] < 192) {
@@ -44,13 +51,13 @@ module.exports = function(bytes, size) {
             // Read at least 32 bytes before making a decision
             if (i > 32 && (suspicious_bytes * 100) / total_bytes > 10) {
                 return true;
-            } 
+            }
         }
     }
 
     if ((suspicious_bytes * 100) / total_bytes > 10) {
         return true;
     }
-    
+
     return false;
 }


### PR DESCRIPTION
Since only the first 512 bytes are considered, only read the first 512 bytes instead of the entire file.

This improves performance noticeably for files in the hundreds of megabytes:

```
> ls -al /tmp/huge.zip
-rw-r--r--  1 kevin  wheel  237545472 May 24 12:24 /tmp/huge.zip

> git co master 
> time bin/isbinaryfile /tmp/huge.zip
real    0m0.250s
user    0m0.067s
sys     0m0.183s

> git co read-first-512-only
> time bin/isbinaryfile /tmp/huge.zip
real    0m0.101s
user    0m0.065s
sys     0m0.035s

```
