### PR TITLE
Fix the example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ However, if you've already read and `stat()`-ed a file (for some other reason), 
 ```javascript
 fs.readFile(process.argv[2], function(err, data) {
 	fs.lstat(process.argv[2], function(err, stat) {
-		if (isBinaryFile(data, stat))
+		if (isBinaryFile(data, stat.size))
 			console.log("It is!")
 		else
 			console.log("No.")


### PR DESCRIPTION
Fix the example in the README to correctly reflect that the second argument to `isBinaryFile` is the size of the file, not the stats object for the file.
