### PR TITLE
Export the isBinaryCheck fuction as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function(bytes, size) {
   return isBinaryCheck(bytes, size);
 }
 
-function isBinaryCheck(bytes, size) {
+module.exports.isBinaryCheck = function isBinaryCheck(bytes, size) {
   if (size === 0)
     return false;
 


### PR DESCRIPTION
I was hoping to use the isBinaryCheck function as I wanted to check the contents of a non-file to see whether they seemed likely to be binary; however that function isn't exported.

Hence this just makes that function get exported as well :-)

I understand if this isn't something you want to do :-)
(Or if you want to do it in a different way)
