### PR TITLE
Export isBinaryCheck function as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,3 +86,5 @@ function isBinaryCheck(bytes, size) {
 
   return false;
 }
+
+module.exports.isBinaryCheck = isBinaryCheck;


### PR DESCRIPTION
I was hoping to use the isBinaryCheck function as I wanted to check the contents of a non-file to see whether they seemed likely to be binary; however that function isn't exported.

Hence this just makes that function get exported as well :-)

I understand if this isn't something you want to do :-)
 (Or if you want to do it in a different way)