### PR TITLE
fix API documentation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install isbinaryfile
 
 ### isBinaryFile(bytes, size, callback)
 
-* `bytes`, an `number` indicating the size of the file.
+* `bytes`, a `Buffer` of the file's contents.
 * `size`, an optional `number` indicating the file size.
 * `callback`, a `function` for the callback. It has two arguments:
   - `err`, the typical Node.js error argument
@@ -41,7 +41,7 @@ npm install isbinaryfile
 
 ### isBinaryFile.sync(bytes, size)
 
-* `bytes`, an `number` indicating the size of the file.
+* `bytes`, a `Buffer` of the file's contents.
 * `size`, an `number` indicating the file size.
 
 
@@ -65,10 +65,6 @@ fs.readFile(process.argv[2], function(err, data) {
       console.log("No.")
   });
 });
-
-isBinaryFile.sync(process.argv[2]); // true or false
-var stat = fs.lstatSync(process.argv[2]);
-isBinaryFile.sync(process.argv[2], stat.size); // true or false
 ```
 
 ## Testing


### PR DESCRIPTION
* When used by [`isBinaryCheck`](https://github.com/gjtorikian/isBinaryFile/blob/b771103b2ac94f2f68771b58973f514882a13af2/index.js#L31), bytes is a Buffer, not a number.
* When `isBinaryFile.sync` is given two arguments, the first is `bytes`, but in the example it is being passed `process.argv[2]` which is a string.