### PR TITLE
use buffer-alloc

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
-var path = require("path");
+var path = require('path');
+var alloc = require('buffer-alloc');
 var MAX_BYTES = 512;
 
 module.exports = function(bytes, size, cb) {
@@ -13,7 +14,7 @@ module.exports = function(bytes, size, cb) {
 
       fs.open(file, 'r', function(r_err, descriptor){
           if (r_err) return cb(r_err);
-          bytes = new Buffer(MAX_BYTES);
+          bytes = alloc(MAX_BYTES);
           // Read the file with no encoding for raw buffer access.
           fs.read(descriptor, bytes, 0, bytes.length, 0, function(err, size, bytes){
             fs.close(descriptor, function(c_err){
@@ -116,7 +117,7 @@ module.exports.sync = function(bytes, size) {
     var descriptor = fs.openSync(file, 'r');
     try {
       // Read the file with no encoding for raw buffer access.
-      bytes = new Buffer(MAX_BYTES);
+      bytes = alloc(MAX_BYTES);
       size = fs.readSync(descriptor, bytes, 0, bytes.length, 0);
     } finally {
       fs.closeSync(descriptor);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "isbinaryfile",
   "description": "Detects if a file is binary in Node.js. Similar to Perl's -B.",
   "version": "3.0.2",
+  "dependencies": {
+    "buffer-alloc": "^1.2.0"
+  },
   "devDependencies": {
     "mocha": "^2.2.4",
     "grunt": "~0.4.1",


### PR DESCRIPTION
Avoid warnings caused by using `new Buffer` in newer versions of Node.