### PR TITLE
protobuf: Properly detect protobuf messages as binary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ function isBinaryCheck(fileBuffer: Buffer, bytesRead: number): boolean {
 
       suspiciousBytes++;
       // Read at least 32 fileBuffer before making a decision
-      if (i > 32 && (suspiciousBytes * 100) / totalBytes > 10) {
+      if (i >= 32 && (suspiciousBytes * 100) / totalBytes > 10) {
         return true;
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,102 @@ const closeAsync = promisify(fs.close);
 
 const MAX_BYTES = 512;
 
+// A very basic non-exception raising reader. Read bytes and
+// at the end use hasError() to check whether this worked.
+class Reader {
+  fileBuffer: Buffer;
+  size: number;
+  offset: number;
+  error: boolean;
+
+  constructor(fileBuffer: Buffer, size: number) {
+    this.fileBuffer = fileBuffer;
+    this.size = size;
+    this.offset = 0;
+    this.error = false;
+  }
+
+  hasError(): boolean {
+    return this.error;
+  }
+
+  nextByte(): number {
+    if (this.offset === this.size || this.hasError()) {
+      this.error = true;
+      return 0xff;
+    }
+    return this.fileBuffer[this.offset++];
+  }
+
+  next(len: number): number[] {
+    const n = new Array();
+    for (let i = 0; i < len; i++) {
+      n[i] = this.nextByte();
+    }
+    return n;
+  }
+}
+
+// Read a Google Protobuf var(iable)int from the buffer.
+function readProtoVarInt(reader: Reader): number {
+  let idx = 0;
+  let varInt = 0;
+
+  while (!reader.hasError()) {
+    const b = reader.nextByte();
+    varInt = varInt | ((b & 0x7f) << (7 * idx));
+    if ((b & 0x80) == 0) {
+      break;
+    }
+    idx++;
+  }
+
+  return varInt;
+}
+
+// Attempt to taste a full Google Protobuf message.
+function readProtoMessage(reader: Reader): boolean {
+  let varInt = readProtoVarInt(reader);
+  const wireType = varInt & 0x7;
+
+  switch (wireType) {
+    case 0:
+      readProtoVarInt(reader);
+      return true;
+    case 1:
+      reader.next(8);
+      return true;
+    case 2:
+      const len = readProtoVarInt(reader);
+      reader.next(len);
+      return true;
+    case 5:
+      reader.next(4);
+      return true;
+  }
+  return false;
+}
+
+// Check whether this seems to be a valid protobuf file.
+function isBinaryProto(fileBuffer: Buffer, totalBytes: number): boolean {
+  const reader = new Reader(fileBuffer, totalBytes);
+  let numMessages = 0;
+
+  while (true) {
+    // Definitely not a valid protobuf
+    if (!readProtoMessage(reader) && !reader.hasError()) {
+      return false;
+    }
+    // Short read?
+    if (reader.hasError()) {
+      break;
+    }
+    numMessages++;
+  }
+
+  return numMessages > 0;
+}
+
 export async function isBinaryFile(file: string | Buffer, size?: number): Promise<boolean> {
   if (isString(file)) {
     const stat = await statAsync(file);
@@ -149,6 +245,10 @@ function isBinaryCheck(fileBuffer: Buffer, bytesRead: number): boolean {
   }
 
   if ((suspiciousBytes * 100) / totalBytes > 10) {
+    return true;
+  }
+
+  if (suspiciousBytes > 1 && isBinaryProto(fileBuffer, totalBytes)) {
     return true;
   }
 

--- a/test/fixtures/protobuf.proto
+++ b/test/fixtures/protobuf.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Something {
+  string entry = 3687091;
+}

--- a/test/fixtures/protobuf.proto.bin
+++ b/test/fixtures/protobuf.proto.bin
@@ -1,0 +1,1 @@
+š«ˆ^A very long string with no suspicous characters that is currently not detected as binary proto

--- a/test/fixtures/protobuf.proto.txt
+++ b/test/fixtures/protobuf.proto.txt
@@ -1,0 +1,1 @@
+entry: "A very long string with no suspicous characters that is currently not detected as binary proto"

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -135,6 +135,7 @@ describe('async', () => {
 
     expect(result).toBe(true);
   });
+
   it("should return false on a protobuf.proto", async () => {
     const file = path.join(FIXTURE_PATH, "protobuf.proto");
 
@@ -144,6 +145,7 @@ describe('async', () => {
 
     expect(result).toBe(false);
   });
+
   it("should return false on a protobuf.proto.txt", async () => {
     const file = path.join(FIXTURE_PATH, "protobuf.proto.txt");
 
@@ -153,6 +155,7 @@ describe('async', () => {
 
     expect(result).toBe(false);
   });
+
   it("should return true on a protobuf.proto.bin", async () => {
     const file = path.join(FIXTURE_PATH, "protobuf.proto.bin");
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -135,6 +135,34 @@ describe('async', () => {
 
     expect(result).toBe(true);
   });
+  it("should return false on a protobuf.proto", async () => {
+    const file = path.join(FIXTURE_PATH, "protobuf.proto");
+
+    expect.assertions(1);
+
+    const result = await isBinaryFile(file);
+
+    expect(result).toBe(false);
+  });
+  it("should return false on a protobuf.proto.txt", async () => {
+    const file = path.join(FIXTURE_PATH, "protobuf.proto.txt");
+
+    expect.assertions(1);
+
+    const result = await isBinaryFile(file);
+
+    expect(result).toBe(false);
+  });
+  it("should return true on a protobuf.proto.bin", async () => {
+    const file = path.join(FIXTURE_PATH, "protobuf.proto.bin");
+
+    expect.assertions(1);
+
+    const result = await isBinaryFile(file);
+
+    expect(result).toBe(true);
+  });
+
 });
 
 describe('sync', () => {


### PR DESCRIPTION
Add testcases for the proto definition, text proto and the
resulting binary. We face the problem that with just 500
bytes we will not be able to fully parse all protobufs but
do our best.

Introduce a reader and start parsing messages. We will bail
when failing to parse a message before having reached the
end of the message.