### PR TITLE
restore engines.node compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typescript": "^3.9.9"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 8.0.0"
   },
   "files": [
     "lib/**/*"


### PR DESCRIPTION
Fix #51 by restoring engines.node compatibility to its pre- 3c4f558
range in order to avoid introducting breaking compatibility changes in
a patch release. While these changes are welcome, they indicate a change
in compatibility and therefore should have been included in a new
major-version release rather than in a patch release.