### PR TITLE
Update typescript target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
Hi and thank you for your work.

This PR updates the typescript target according to the [@tsconfig/node18](https://www.npmjs.com/package/@tsconfig/node18) npm package as currently in the package.json engines filed the minimum supported nodejs version is 18. The main benefit of this change is that typescript will no longer need to transform async functions and inline an `__awaiter` helper in every file where async functions are used. This results the output code closer resembling the source code as well as less code being shipped to npm.